### PR TITLE
Add deviceId to firmware event handler callback argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ class MiFlora extends EventEmitter {
   parseFirmwareData(peripheral, data) {
     debug('firmware data:', data);
     let firmware = {
+      deviceId: peripheral.id,
       batteryLevel: parseInt(data.toString('hex', 0, 1), 16),
       firmwareVersion: data.toString('ascii', 2, data.length)
     };


### PR DESCRIPTION
So we know which device firmware version and battery status we are receiving. 

PS: Great job with this library! I love it.